### PR TITLE
Update example to use Scala 3.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 In this repo we have a simple project structure simulating a test framework:
 
 - `testframework`: a library that provides a position macro that can be consumed from either Scala `2.13` or `3.0`
-  - compiled with Dotty `3.0.0-M1`
+  - compiled with Dotty `3.0.2`
   - depends on `shared`, `scala2macros`
 - `shared`: provides data structures used by macros
-  - compiled with Dotty `3.0.0-M1`
+  - compiled with Dotty `3.0.2`
 - `scala2macros`: provides implementation of macros for Scala 2
-  - compiled with Scala `2.13.4`
+  - compiled with Scala `2.13.7`
   - depends on `shared`
 - `app2`: the demo Scala 2 application that uses the test framework
-  - compiled with Scala `2.13.4`
+  - compiled with Scala `2.13.7`
   - depends on `testframework`
 - `app3`: replicates the demo application for `app2` but compiled with Scala 3
   - using the exact same library dependencies
-  - compiled with Dotty `3.0.0-M1`
+  - compiled with Dotty `3.0.2`
 
 The main macro we use is `def pos: Position` which summons a data structure containing the source file and line number of the callsite. This is called in [Main.scala](src/main/scala/Main.scala).
 

--- a/app3/src/main/scala/Main.scala
+++ b/app3/src/main/scala/Main.scala
@@ -1,4 +1,4 @@
-import testframework.{_, given _}
+import testframework.{_, given}
 
 object Main extends App {
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-ThisBuild / scalaVersion := "3.0.0-M1"
-val scala213 = "2.13.4"
+ThisBuild / scalaVersion := "3.0.2"
+val scala213 = "2.13.7"
 
 lazy val scala2macros = project
   .dependsOn(shared)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.3
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")

--- a/testframework/src/main/scala/testframework/Macros.scala
+++ b/testframework/src/main/scala/testframework/Macros.scala
@@ -1,16 +1,16 @@
 package testframework
 
-import quoted._
+import scala.quoted._
 
 object Macros:
 
-  def posImpl(using qctx: QuoteContext): Expr[Position] =
-    import qctx.reflect.given
-    val name = qctx.reflect.rootPosition.sourceFile.jpath.getFileName.toString
-    val line = qctx.reflect.rootPosition.startLine + 1
+  def posImpl(using quotes: Quotes): Expr[Position] =
+    import quotes.reflect.given
+    val name = quotes.reflect.SourceFile.current.jpath.getFileName.toString
+    val line = quotes.reflect.Position.ofMacroExpansion.startLine + 1
     '{ Position(${Expr(name)}, ${Expr(line)}) }
 
-  def mkTpeTagImpl[T: Type](using qctx: QuoteContext): Expr[TpeTag[T]] =
-    '{ TpeTag(${Expr(Type[T].show)}) }
+  def mkTpeTagImpl[T: Type](using quotes: Quotes): Expr[TpeTag[T]] =
+    '{ TpeTag(${Expr(Type.show[T])}) }
 
-  def actuallyAnIntImpl(using qctx: QuoteContext): Expr[Int] = Expr(23)
+  def actuallyAnIntImpl(using quotes: Quotes): Expr[Int] = Expr(23)

--- a/testframework/src/main/scala/testframework/package.scala
+++ b/testframework/src/main/scala/testframework/package.scala
@@ -3,10 +3,10 @@ package object testframework:
   import scala.language.experimental.macros
 
   implicit def pos: Position = macro Scala2Macros.posImpl
-  inline given pos as Position = ${ Macros.posImpl }
+  inline given pos: Position = ${ Macros.posImpl }
 
   implicit def mkTpeTag[T]: TpeTag[T] = macro Scala2Macros.TpeTagImpl.mkTag[T]
-  inline given mkTpeTag[T] as TpeTag[T] = ${ Macros.mkTpeTagImpl[T] }
+  inline given mkTpeTag[T]: TpeTag[T] = ${ Macros.mkTpeTagImpl[T] }
 
   def actuallyAnInt: Any = macro Scala2Macros.Whitebox.actuallyAnIntImpl
   transparent inline def actuallyAnInt: Any = ${ Macros.actuallyAnIntImpl }


### PR DESCRIPTION
Macros changed in some small ways between Scala 3.0.0-M1 and Scala 3.0.2. SBT version support has also changed. Since this is intended to be an example project, having it be as current as possible is helpful for developers who will refer to it.